### PR TITLE
Feature/fields refactor

### DIFF
--- a/app/posts/custom_fields.php
+++ b/app/posts/custom_fields.php
@@ -209,9 +209,9 @@ if(function_exists("register_field_group"))
     'location' => array (
       array (
         array (
-          'param' => 'page_template',
+          'param' => 'page_type',
           'operator' => '==',
-          'value' => 'page-home.php',
+          'value' => 'front_page',
           'order_no' => 0,
           'group_no' => 0,
         ),
@@ -221,6 +221,7 @@ if(function_exists("register_field_group"))
       'position' => 'normal',
       'layout' => 'default',
       'hide_on_screen' => array (
+        0 => 'the_content',
       ),
     ),
     'menu_order' => 0,
@@ -246,9 +247,9 @@ if(function_exists("register_field_group"))
     'location' => array (
       array (
         array (
-          'param' => 'page_template',
+          'param' => 'page_type',
           'operator' => '==',
-          'value' => 'page-home.php',
+          'value' => 'front_page',
           'order_no' => 0,
           'group_no' => 0,
         ),
@@ -258,6 +259,7 @@ if(function_exists("register_field_group"))
       'position' => 'normal',
       'layout' => 'default',
       'hide_on_screen' => array (
+        0 => 'the_content',
       ),
     ),
     'menu_order' => 0,
@@ -318,9 +320,9 @@ if(function_exists("register_field_group"))
     'location' => array (
       array (
         array (
-          'param' => 'page_template',
+          'param' => 'page_type',
           'operator' => '==',
-          'value' => 'page-home.php',
+          'value' => 'front_page',
           'order_no' => 0,
           'group_no' => 0,
         ),
@@ -330,6 +332,7 @@ if(function_exists("register_field_group"))
       'position' => 'side',
       'layout' => 'default',
       'hide_on_screen' => array (
+        0 => 'the_content',
       ),
     ),
     'menu_order' => 0,

--- a/app/posts/custom_fields.php
+++ b/app/posts/custom_fields.php
@@ -5,13 +5,22 @@ if(function_exists("register_field_group"))
 
   // Homepage template
   register_field_group(array (
-    'id' => 'acf_main-call-to-action',
-    'title' => 'Main call to action',
+    'id' => 'acf_page-banner',
+    'title' => 'Page Banner',
     'fields' => array (
       array (
+        'key' => 'field_5582d48263aff',
+        'label' => 'Banner content',
+        'name' => 'banner_content',
+        'type' => 'wysiwyg',
+        'default_value' => '',
+        'toolbar' => 'full',
+        'media_upload' => 'yes',
+      ),
+      array (
         'key' => 'field_543561833db70',
-        'label' => 'Main button description',
-        'name' => 'main_button_description',
+        'label' => 'Button description',
+        'name' => 'banner_button_description',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',
@@ -22,8 +31,8 @@ if(function_exists("register_field_group"))
       ),
       array (
         'key' => 'field_5435618c3db71',
-        'label' => 'Main button URL',
-        'name' => 'main_button_url',
+        'label' => 'Button URL',
+        'name' => 'banner_button_url',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',
@@ -36,9 +45,9 @@ if(function_exists("register_field_group"))
     'location' => array (
       array (
         array (
-          'param' => 'page_template',
+          'param' => 'page_type',
           'operator' => '==',
-          'value' => 'page-home.php',
+          'value' => 'front_page',
           'order_no' => 0,
           'group_no' => 0,
         ),
@@ -48,11 +57,12 @@ if(function_exists("register_field_group"))
       'position' => 'acf_after_title',
       'layout' => 'default',
       'hide_on_screen' => array (
+        0 => 'the_content',
       ),
     ),
     'menu_order' => 0,
   ));
-  
+
   register_field_group(array (
     'id' => 'acf_images',
     'title' => 'Images',

--- a/app/posts/custom_fields.php
+++ b/app/posts/custom_fields.php
@@ -391,18 +391,9 @@ if(function_exists("register_field_group"))
     'title' => 'Content blocks',
     'fields' => array (
       array (
-        'key' => 'field_543e74bae75df',
-        'label' => 'Blocks with images',
-        'name' => 'blocks_with_images',
-        'type' => 'true_false',
-        'instructions' => 'Include horizontal images?',
-        'message' => '',
-        'default_value' => 0,
-      ),
-      array (
         'key' => 'field_543e740d941c5',
         'label' => 'Left block title',
-        'name' => 'left_block_title',
+        'name' => 'block_title_1',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',
@@ -414,7 +405,7 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e7442941c7',
         'label' => 'Left block text',
-        'name' => 'left_block_text',
+        'name' => 'block_text_1',
         'type' => 'wysiwyg',
         'default_value' => '',
         'toolbar' => 'full',
@@ -423,19 +414,8 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e7425941c6',
         'label' => 'Left block image',
-        'name' => 'left_block_image',
+        'name' => 'block_image_1',
         'type' => 'image',
-        'conditional_logic' => array (
-          'status' => 1,
-          'rules' => array (
-            array (
-              'field' => 'field_543e74bae75df',
-              'operator' => '==',
-              'value' => '1',
-            ),
-          ),
-          'allorany' => 'all',
-        ),
         'save_format' => 'object',
         'preview_size' => 'thumbnail',
         'library' => 'all',
@@ -443,7 +423,7 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e748eafd9e',
         'label' => 'Left block call to action',
-        'name' => 'left_block_call_to_action',
+        'name' => 'block_call_to_action_1',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',
@@ -455,7 +435,7 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e749dafd9f',
         'label' => 'Left block URL',
-        'name' => 'left_block_url',
+        'name' => 'block_url_1',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',
@@ -467,7 +447,7 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e75a364eaf',
         'label' => 'Right block title',
-        'name' => 'right_block_title',
+        'name' => 'block_title_2',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',
@@ -479,7 +459,7 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e75af64eb0',
         'label' => 'Right block text',
-        'name' => 'right_block_text',
+        'name' => 'block_text_2',
         'type' => 'wysiwyg',
         'default_value' => '',
         'toolbar' => 'full',
@@ -488,19 +468,8 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e75c464eb1',
         'label' => 'Right block image',
-        'name' => 'right_block_image',
+        'name' => 'block_image_2',
         'type' => 'image',
-        'conditional_logic' => array (
-          'status' => 1,
-          'rules' => array (
-            array (
-              'field' => 'field_543e74bae75df',
-              'operator' => '==',
-              'value' => '1',
-            ),
-          ),
-          'allorany' => 'all',
-        ),
         'save_format' => 'object',
         'preview_size' => 'thumbnail',
         'library' => 'all',
@@ -508,7 +477,7 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e75d364eb2',
         'label' => 'Right block call to action',
-        'name' => 'right_block_call_to_action',
+        'name' => 'block_call_to_action_2',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',
@@ -520,7 +489,7 @@ if(function_exists("register_field_group"))
       array (
         'key' => 'field_543e75e464eb3',
         'label' => 'Right block URL',
-        'name' => 'right_block_url',
+        'name' => 'block_url_2',
         'type' => 'text',
         'default_value' => '',
         'placeholder' => '',

--- a/templates/front-page.php
+++ b/templates/front-page.php
@@ -1,8 +1,4 @@
-<?php
-/**
- * Template name: home
- */
-the_post() ?>
+<?php the_post() ?>
 
 <main id="content" role="main" class="main">
 

--- a/templates/page-campaign.php
+++ b/templates/page-campaign.php
@@ -39,45 +39,15 @@ the_post();
           </div>
         </div>
 
-        <?php if (get_field('left_block_title')) : ?>
+        <div class="page-element">
+          <ul class="small-block-grid-1 medium-block-grid-2">
+            <?php for( $i=1; $i<3; $i++ ) : ?>
+              <?php set_query_var('idx', $i) ?>
 
-          <div class="page-element">
-            <ul class="small-block-grid-1 medium-block-grid-2">
-              <li>
-                <article>
-                  <?php $image1 = get_field('left_block_image'); $thumb1 = $image1['sizes']['large']; ?>
-                  <header>
-                    <h3><?php the_field('left_block_title') ?></h3>
-                  </header>
-
-                  <?php if (get_field('blocks_with_images') == true ) : ?>
-                    <a class="image" href="<?php the_field('left_block_url'); ?>"><img class="thumb" src="<?php echo $thumb1; ?>" alt="<?php echo $image1['alt']; ?>"></a>
-                  <?php endif ?>
-
-                  <?php echo get_field('left_block_text'); ?>
-                  <a href="<?php the_field('left_block_url'); ?>" class="button"><?php the_field('left_block_call_to_action'); ?></a>
-                </article>
-              </li>
-              <li>
-                <article>
-                  <?php $image2 = get_field('right_block_image'); $thumb2 = $image2['sizes']['large']; ?>
-
-                  <header>
-                    <h3><?php the_field('right_block_title') ?></h3>
-                  </header>
-
-                  <?php if (get_field('blocks_with_images') == true ) : ?>
-                    <a class="image" href="<?php the_field('right_block_url'); ?>"><img class="thumb" src="<?php echo $thumb2; ?>" alt="<?php echo $image2['alt']; ?>"></a>
-                  <?php endif ?>
-
-                  <?php echo get_field('right_block_text'); ?>
-                  <a href="<?php the_field('right_block_url'); ?>" class="button"><?php the_field('right_block_call_to_action'); ?></a>
-                </article>
-              </li>
-            </ul>
-          </div>
-
-        <?php endif ?>
+              <li><?php get_template_part('partials/loop', 'image-block') ?></li>
+            <?php endfor ?>
+          </ul>
+        </div>
 
       </div>
     </div>

--- a/templates/partials/loop-image-block.php
+++ b/templates/partials/loop-image-block.php
@@ -1,0 +1,12 @@
+<article>
+  <header>
+    <h3><?php the_field('block_title_'.$idx) ?></h3>
+  </header>
+
+  <?php if ( $image = get_field('block_image_'.$idx) ) : ?>
+    <a class="image" href="<?php the_field('block_url_'.$idx) ?>"><img class="thumb" src="<?php echo $image['sizes']['large'] ?>" alt="<?php echo $image['alt'] ?>"></a>
+  <?php endif ?>
+
+  <?php the_field('block_text_'.$idx) ?>
+  <a href="<?php the_field('block_url_'.$idx) ?>" class="button"><?php the_field('block_call_to_action_'.$idx) ?></a>
+</article>

--- a/templates/partials/page-banner.php
+++ b/templates/partials/page-banner.php
@@ -2,10 +2,10 @@
   <div class="row">
     <div class="large-12 columns">
       <article class="rte">
-        <?php the_content(); ?>
+        <?php the_field('banner_content'); ?>
       </article>
-      <?php if (get_field('main_button_url')) : ?>
-        <a href="<?php the_field('main_button_url'); ?>" title="<?php the_field('main_button_description'); ?>" class="button-banner"><?php the_field('main_button_description'); ?></a>
+      <?php if (get_field('banner_button_url')) : ?>
+        <a href="<?php the_field('banner_button_url'); ?>" title="<?php the_field('banner_button_description'); ?>" class="button-banner"><?php the_field('banner_button_description'); ?></a>
       <?php endif ?>
     </div>
   </div>


### PR DESCRIPTION
Mostly a bit of a proof of concept here... 

Changed the Page Banner partial to use Custom fields only and not rely on post_content. Can then be re-used across multiple templates if required. This is the best example of a template driven approach to modules. The ACF fields can be anywhere and the partial just be included in any other main template.

Other changes include switching the `page-home.php` file to be `front-page.php` using WordPress conventions and switch all custom fields to be targeted to the front-page page type.

Edited the campaign page blocks into a single partial and changed custom fields to help accommodate the change. Still not sure about this, the template is kind of reusable but requires numbered fields - may look into a way of refactoring further to allow this block to be used as a flexible content layout on the premium version.

Warning, may conflict with #32 if that one is merged before this due to editing a similar partial. Should maybe have merged that feature branch into this one to create a dependency. Either way, comments would be appreciated and I'm happy to deal with the conflicts. 